### PR TITLE
Rewrite homepage card descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,9 +102,11 @@ head_inject: >-
                             <i class="pe-7s-pen"></i>
                         </div>
                         <h3>Scholarship</h3>
-                        <p class="description">Dedicated to excellence in
-                            research and innovation, my work aims to expand
-                            boundaries and explore new horizons</p>
+                        <p class="description">I write about mathematics,
+                            operations research, technology, public policy,
+                            and the places where they collide. Sometimes this
+                            results in papers. Sometimes books. Occasionally
+                            something stranger.</p>
                     </div>
                 </div>
             </a>
@@ -116,9 +118,10 @@ head_inject: >-
                             <i class="pe-7s-study"></i>
                         </div>
                         <h3>Teaching</h3>
-                        <p class="description">Fostering growth and discovery
-                            through mentorship, I guide learners on a journey of
-                            knowledge and self-discovery</p>
+                        <p class="description">I teach mathematics and
+                            statistics by starting with the problem and working
+                            backward to the machinery. Getting the answer
+                            matters. Understanding why it works matters more.</p>
                     </div>
                 </div>
             </a>
@@ -129,9 +132,11 @@ head_inject: >-
                             <i class="pe-7s-culture"></i>
                         </div>
                         <h3>Service</h3>
-                        <p class="description">Committed to making a difference
-                            through public service, I strive to contribute
-                            positively to our community and beyond</p>
+                        <p class="description">Public service is where theory
+                            has to survive contact with reality. I have served
+                            in local government, the Maryland Defense Force,
+                            professional societies, and a collection of other
+                            useful places.</p>
                     </div>
                 </div>
             </a>
@@ -144,11 +149,10 @@ head_inject: >-
                             <i class="pe-7s-ball"></i>
                         </div>
                         <h3>Games</h3>
-                        <p class="description">
-                            Exploring creativity through interactive
-                            experiences, I once designed a game to engage the
-                            mind and entertain
-                        </p>
+                        <p class="description">I wrote a GURPS supplement about
+                            hurricanes. This is either game writing, disaster
+                            research, or evidence that I will turn almost
+                            anything into a project.</p>
                     </div>
                 </div>
             </a>
@@ -159,11 +163,10 @@ head_inject: >-
                             <i class="pe-7s-notebook"></i>
                         </div>
                         <h3>My Books</h3>
-                        <p class="description">
-                            Authoring and editing books that span a range of
-                            topics, I strive to contribute meaningful insights
-                            to the fields of my expertise
-                        </p>
+                        <p class="description">I have written and edited books
+                            on numerical analysis, online mathematics education,
+                            flood insurance, and military operations research.
+                            Apparently I do not believe in picking a lane.</p>
                     </div>
                 </div>
             </a>
@@ -174,11 +177,10 @@ head_inject: >-
                             <i class="pe-7s-micro"></i>
                         </div>
                         <h3>Media Appearance</h3>
-                        <p class="description">
-                            From interviews to in-depth profiles, my media
-                            appearances have allowed me to share my work with a
-                            broader audience
-                        </p>
+                        <p class="description">Every so often somebody asks me
+                            to explain something on television, radio, or in
+                            print. I generally say yes, because explaining
+                            complicated things is most of the fun.</p>
                     </div>
                 </div>
             </a>
@@ -189,11 +191,10 @@ head_inject: >-
                             <i class="pe-7s-diskette"></i>
                         </div>
                         <h3>Software</h3>
-                        <p class="description">
-                            My software projects are a blend of innovation and
-                            practicality, developed to solve problems, automate
-                            tasks, or simply bring ideas to life
-                        </p>
+                        <p class="description">I have been writing software
+                            since Unix boxes were considerably more annoying.
+                            Some of it solves real problems; some of it exists
+                            because I wanted to know whether the idea would work.</p>
                     </div>
                 </div>
             </a>
@@ -246,7 +247,7 @@ head_inject: >-
                     <div class="content">
                         <a href="{{ '/blog' | relative_url }}"
                            class="card-title" aria-label="{{ post.title }}"><h3>Blog</h3></a>
-                        <p class="text-description text-gray card-blog-excerpt">Click here for older posts...</p>
+                        <p class="text-description text-gray card-blog-excerpt">The archive: essays, explainers, arguments, side quests, and things I apparently needed to calculate.</p>
                     </div>
                 </div>
             </div>
@@ -273,10 +274,10 @@ head_inject: >-
                                 <i class="pe-7s-medal"></i>
                             </div>
                             <h3 class="text-white">Honors</h3>
-                            <p class="description text-white">
-                                Recognitions and awards that reflect my
-                                contributions across various fields
-                            </p>
+                            <p class="description text-white">Professional
+                                honors, civic awards, fellowships, medals, and a
+                                few things that require considerably more
+                                explanation than the others.</p>
                         </div>
                     </div>
                 </a>
@@ -287,10 +288,10 @@ head_inject: >-
                                 <i class="pe-7s-shield"></i>
                             </div>
                             <h3 class="text-white">Coat of Arms</h3>
-                            <p class="description text-white">
-                                A visual expression of identity, lineage, and
-                                aspiration drawn from heraldic tradition
-                            </p>
+                            <p class="description text-white">Yes, I have a
+                                coat of arms. Here are the grant, the design,
+                                the history, and considerably more heraldry than
+                                anyone reasonably needs.</p>
                         </div>
                     </div>
                 </a>
@@ -302,10 +303,10 @@ head_inject: >-
                                 <i class="pe-7s-users"></i>
                             </div>
                             <h3 class="text-white">Ancestry</h3>
-                            <p class="description text-white">
-                                Journey into my family's past, exploring the
-                                stories, traditions, and people who led to me
-                            </p>
+                            <p class="description text-white">Genealogy is
+                                mostly an exercise in refusing to believe family
+                                stories until the paperwork shows up. Here are
+                                the ancestors, records, societies, and evidence.</p>
                         </div>
                     </div>
                 </a>


### PR DESCRIPTION
Editorial-only homepage-card copy refresh. This changes `index.html` only; it preserves card titles, destinations, structure, and styling.\n\nThe supplied copy was applied verbatim, with no wording adjustments.