### PR TITLE
Add homepage What I Do section

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ head_inject: >-
     </div>
 
     <div>
-        <a href="#firstSection" data-scroll="true" data-id="#firstSection" class="scroll-arrow hidden-xs hidden-sm" aria-label="Read more about James Howard">
+        <a href="#what-i-do" data-scroll="true" data-id="#what-i-do" class="scroll-arrow hidden-xs hidden-sm" aria-label="Read more about James Howard">
             <div class="icon front-page-arrow">
                 <i class="pe-7s-angle-down-circle"></i>
             </div>
@@ -83,11 +83,17 @@ head_inject: >-
 
 </div>
 
-<div class="section section-homepage-positioning">
+<div class="section section-homepage-positioning" id="what-i-do" style="background-color: #14488a; padding: 65px 0 60px;">
     <div class="container">
+        <div class="title-area" style="margin-bottom: 25px;">
+            <h2 class="text-warning">What I Do</h2>
+            <div class="separator separator-warning">
+                <img src="{{ '/assets/img/identity/kamon-warning.svg' | relative_url }}" height="35" alt="" />
+            </div>
+        </div>
         <div class="row">
             <div class="col-md-8 col-md-offset-2">
-                <p class="lead text-center">I use mathematics, statistics, software, and artificial intelligence to understand complicated systems—and explain what they mean when people and institutions have to make decisions.</p>
+                <p class="lead text-center text-white" style="margin-bottom: 0;">I use mathematics, statistics, software, and artificial intelligence to understand complicated systems—and explain what they mean when people and institutions have to make decisions.</p>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ head_inject: >-
 
 </div>
 
-<div class="section section-homepage-positioning" id="what-i-do" style="background-color: #14488a; padding: 65px 0 60px;">
+<div class="section section-homepage-positioning" id="what-i-do" style="background-color: #2b3c52; padding: 65px 0 60px;">
     <div class="container">
         <div class="title-area" style="margin-bottom: 25px;">
             <h2 class="text-warning">What I Do</h2>
@@ -93,7 +93,7 @@ head_inject: >-
         </div>
         <div class="row">
             <div class="col-md-8 col-md-offset-2">
-                <p class="lead text-center text-white" style="margin-bottom: 0;">I use mathematics, statistics, software, and artificial intelligence to understand complicated systems—and explain what they mean when people and institutions have to make decisions.</p>
+                <p class="lead text-center text-white" style="color: #fff; margin-bottom: 0;">I use mathematics, statistics, software, and artificial intelligence to understand complicated systems—and explain what they mean when people and institutions have to make decisions.</p>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -83,6 +83,16 @@ head_inject: >-
 
 </div>
 
+<div class="section section-homepage-positioning">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8 col-md-offset-2">
+                <p class="lead text-center">I use mathematics, statistics, software, and artificial intelligence to understand complicated systems—and explain what they mean when people and institutions have to make decisions.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="section" id="firstSection">
     <div class="container">
         <div class="row">


### PR DESCRIPTION
Promotes the homepage positioning statement into a distinct full-width **What I Do** section between the hero and “Explore My World.”

## Final treatment

- Existing positioning copy is retained unchanged.
- Section uses the established JamesHoward.us blue (`#14488a`).
- “What I Do” heading and separator use the existing gold/warning treatment.
- Statement text is white and remains centered in the existing Bootstrap grid.
- The hero scroll arrow now lands on the new `#what-i-do` section instead of skipping past it to “Explore My World.”
- No navigation, metadata, card, or destination changes.

## Implemented copy

> I use mathematics, statistics, software, and artificial intelligence to understand complicated systems—and explain what they mean when people and institutions have to make decisions.

This replaces the earlier visually understated white-band treatment after review showed that the statement did not carry enough hierarchy between the hero and the exploration cards.