### PR TITLE
Rebuild Software as a curated project portfolio

### DIFF
--- a/_data/software.yml
+++ b/_data/software.yml
@@ -31,45 +31,24 @@ current:
       - label: Opening note
         url: /2026/08/11/the-fatal-image-is-now-open/
 
-  - name: Interlocks
-    status: Current
-    period: 2026–present
-    technology: JavaScript · web application · policy engine
-    summary: >-
-      A provenance-first system for institutional conflicts. It keeps facts,
-      relationships, evidence, policy questions, mitigations, and human judgment
-      distinct, because a machine can identify a connection without pretending
-      that it has made the professional decision.
-    links:
-      - label: Source
-        url: https://github.com/howardjp/interlocks
-
-  - name: Greystoke
-    status: Experimental
-    period: 2026–present
-    technology: C · operating-systems research
-    summary: >-
-      A capability-oriented microkernel experiment derived from NetBSD. It asks
-      what a modern Mach-like system might look like when portability boundaries,
-      hardware protection, and explicit evidence are treated as design
-      constraints rather than afterthoughts.
-    links:
-      - label: Source
-        url: https://github.com/howardjp/greystoke
-
-  - name: Queen City Yard
-    status: Experimental
-    period: 2026
-    technology: NW.js · arcade game
-    summary: >-
-      A hump-tower arcade game: a deliberately nontraditional software project
-      built around switching, timing, and the satisfying problem of getting a
-      railway yard to do what it is told.
-    links:
-      - label: Source
-        url: https://github.com/howardjp/hump-tower
-
 maintained:
+  - name: Kami
+    status: Stable
+    period: 2021–2023
+    technology: Modern C++ · agent-based modeling
+    summary: >-
+      An agent-based modeling library in modern C++, developed at the Johns
+      Hopkins Applied Physics Laboratory. It provides the pieces for modeling
+      individual actors and their environments when collective behavior cannot
+      be treated as a simple aggregate.
+    links:
+      - label: Source
+        url: https://github.com/JHUAPL/kami
+      - label: Documentation
+        url: https://kami.readthedocs.io/en/main/
+      - label: Release archive
+        url: https://github.com/JHUAPL/kami/releases
+
   - name: phonics
     status: Maintained
     period: 2015–present

--- a/_data/software.yml
+++ b/_data/software.yml
@@ -3,6 +3,7 @@ current:
     status: Current
     period: 2026–present
     technology: Python · command line · SVG
+    image: /assets/img/2025/a-new-tartan.webp
     summary: >-
       A package and command-line utility for defining, validating, rendering,
       and exporting tartans from YAML. It uses one SVG-first rendering model so
@@ -18,6 +19,7 @@ current:
     status: Current
     period: 2026–present
     technology: TypeScript · digital humanities · static web application
+    image: /assets/img/2026/the-fatal-image-is-now-open.webp
     summary: >-
       A virtual exhibition that makes an art-historical argument through an
       explorable corpus rather than a long page of labels. The public exhibition

--- a/_data/software.yml
+++ b/_data/software.yml
@@ -1,0 +1,220 @@
+current:
+  - name: tartan-maker
+    status: Current
+    period: 2026–present
+    technology: Python · command line · SVG
+    summary: >-
+      A package and command-line utility for defining, validating, rendering,
+      and exporting tartans from YAML. It uses one SVG-first rendering model so
+      that the design data, the visible sett, and exported images do not quietly
+      become three different things.
+    links:
+      - label: Project documentation
+        url: https://k3jph.github.io/tartan-maker/
+      - label: Source
+        url: https://github.com/k3jph/tartan-maker
+
+  - name: "Judith & Holofernes: The Fatal Image"
+    status: Current
+    period: 2026–present
+    technology: TypeScript · digital humanities · static web application
+    summary: >-
+      A virtual exhibition that makes an art-historical argument through an
+      explorable corpus rather than a long page of labels. The public exhibition
+      currently connects 58 works across eight centuries, with the supporting
+      research, images, and interface treated as one project.
+    links:
+      - label: Visit the exhibition
+        url: https://judith.jameshoward.us/
+      - label: Source
+        url: https://github.com/k3jph/judith.jameshoward.us
+      - label: Opening note
+        url: /2026/08/11/the-fatal-image-is-now-open/
+
+  - name: Interlocks
+    status: Current
+    period: 2026–present
+    technology: JavaScript · web application · policy engine
+    summary: >-
+      A provenance-first system for institutional conflicts. It keeps facts,
+      relationships, evidence, policy questions, mitigations, and human judgment
+      distinct, because a machine can identify a connection without pretending
+      that it has made the professional decision.
+    links:
+      - label: Source
+        url: https://github.com/howardjp/interlocks
+
+  - name: Greystoke
+    status: Experimental
+    period: 2026–present
+    technology: C · operating-systems research
+    summary: >-
+      A capability-oriented microkernel experiment derived from NetBSD. It asks
+      what a modern Mach-like system might look like when portability boundaries,
+      hardware protection, and explicit evidence are treated as design
+      constraints rather than afterthoughts.
+    links:
+      - label: Source
+        url: https://github.com/howardjp/greystoke
+
+  - name: Queen City Yard
+    status: Experimental
+    period: 2026
+    technology: NW.js · arcade game
+    summary: >-
+      A hump-tower arcade game: a deliberately nontraditional software project
+      built around switching, timing, and the satisfying problem of getting a
+      railway yard to do what it is told.
+    links:
+      - label: Source
+        url: https://github.com/howardjp/hump-tower
+
+maintained:
+  - name: phonics
+    status: Maintained
+    period: 2015–present
+    technology: R · CRAN package
+    summary: >-
+      Phonetic encoders for English, German, and French names, plus comparison
+      methods used in record linkage. It began with a county-data merge that
+      needed more than wishful spelling normalization and became published,
+      citable research software.
+    links:
+      - label: CRAN package
+        url: https://cran.r-project.org/package=phonics
+      - label: Source
+        url: https://github.com/k3jph/phonics-in-r
+      - label: JSS article
+        url: https://doi.org/10.18637/jss.v095.i08
+
+  - name: cmna
+    status: Maintained
+    period: 2016–present
+    technology: R · numerical analysis
+    summary: >-
+      The companion package to Computational Methods for Numerical Analysis with
+      R. It puts the algorithms from the book in runnable, inspectable form so
+      that approximation, error, and numerical choices can be seen rather than
+      merely asserted.
+    links:
+      - label: CRAN package
+        url: https://cran.r-project.org/package=cmna
+      - label: Source
+        url: https://github.com/k3jph/cmna-pkg
+      - label: Book
+        url: /cmna
+
+  - name: waterfall
+    status: Stable
+    period: 2010–2016
+    technology: R · data visualization
+    summary: >-
+      A compact R package for waterfall charts in base and lattice graphics,
+      built to make the strange accounting of public organizations easier to
+      reason about. The work is complete rather than actively expanding.
+    links:
+      - label: CRAN package
+        url: https://cran.r-project.org/package=waterfall
+      - label: Source
+        url: https://github.com/k3jph/waterfall
+      - label: Release note
+        url: /2016/02/15/waterfall-1-0-0-released/
+
+archive:
+  - name: FreeGrep
+    status: Historical
+    period: 1999–2010
+    technology: C · BSD / Unix
+    summary: >-
+      A BSD-licensed implementation of grep, originally written to understand
+      finite-state matching and later adopted into the source trees of both
+      NetBSD and OpenBSD; it subsequently became the standard grep in Minix 3.
+    links:
+      - label: Source archive
+        url: https://github.com/k3jph/freegrep
+      - label: Project history
+        url: /2009/11/25/freegrep-is-now-at-github/
+
+  - name: Virtual Bumblebees
+    status: Historical
+    period: 2015–2017
+    technology: JavaScript · cellular automata
+    summary: >-
+      An artificial-life environment based on a deliberately different reading
+      of Langton’s ant: place bees and dots on the board, then watch a simple
+      rule system produce behavior that is considerably less simple.
+    links:
+      - label: Try it
+        url: https://k3jph.github.io/bumblebees/
+      - label: Source
+        url: https://github.com/k3jph/bumblebees
+      - label: Project note
+        url: /2015/03/14/introducing-my-bumblebees/
+
+  - name: WS2812B SPI Controller for ATtiny85
+    status: Historical
+    period: 2021–2022
+    technology: C · AVR · embedded systems
+    summary: >-
+      Firmware for driving WS2812B LEDs through SPI on an ATtiny85, built around
+      a timing protocol that is simple in the way a bear trap is simple.
+    links:
+      - label: Source
+        url: https://github.com/k3jph/ws2812b-spi-controller
+      - label: Project note
+        url: /2022/05/09/ws2818b-spi-controller-for-attiny85/
+
+  - name: Phonics in Rust
+    status: Historical
+    period: 2019–2020
+    technology: Rust · crates.io
+    summary: >-
+      A partial Rust port of phonics, written as a serious attempt to learn the
+      language by translating a known problem into idiomatic traits, types, and
+      testable components rather than by producing another calculator.
+    links:
+      - label: Source
+        url: https://github.com/k3jph/phonics-in-rust
+      - label: Crate
+        url: https://crates.io/crates/phonics
+
+  - name: LX
+    status: Historical
+    period: 2009
+    technology: PHP · CakePHP · PostgreSQL
+    summary: >-
+      An unfinished custom-domain link shortener released as source when the
+      obvious commercial entrants arrived. It is kept as an honest artifact of a
+      useful idea that did not need to become a product.
+    links:
+      - label: Source archive
+        url: https://github.com/k3jph/lx
+      - label: Project note
+        url: /2009/12/16/source-code-for-lx-a-link-shortener/
+
+  - name: Small Unix utilities
+    status: Historical
+    period: 1997–1998
+    technology: C · BSD / Unix
+    summary: >-
+      daemon, rpt, uwatch, and write are small programs from the era when a
+      utility could be worth having simply because it did one job cleanly. They
+      are preserved as source and as a record of the systems work that preceded
+      the larger projects.
+    links:
+      - label: Archive note
+        url: /2009/12/10/more-old-code-at-github/
+
+  - name: Kivu Ebola analysis
+    status: Historical
+    period: 2019–2020
+    technology: R · epidemiological modeling
+    summary: >-
+      A reproducible analysis repository for the 2018–2019 Kivu Ebola outbreak,
+      retained as a research artifact alongside the resulting Joint Statistical
+      Meetings presentation.
+    links:
+      - label: Source archive
+        url: https://github.com/k3jph/ebola-kivu-2018-19
+      - label: Presentation note
+        url: /2020/08/05/jsm-presentation-on-ebola/

--- a/_includes/software-projects.html
+++ b/_includes/software-projects.html
@@ -1,0 +1,14 @@
+{% for project in include.projects %}
+<article class="software-project">
+  <header>
+    <h3>{{ project.name }}</h3>
+    <p class="software-project-meta"><span class="software-project-status">{{ project.status }}</span> · {{ project.period }} · {{ project.technology }}</p>
+  </header>
+  <p>{{ project.summary }}</p>
+  <p class="software-project-links">
+    {% for link in project.links %}
+      <a href="{{ link.url | relative_url }}">{{ link.label }}</a>{% unless forloop.last %}<span aria-hidden="true"> · </span>{% endunless %}
+    {% endfor %}
+  </p>
+</article>
+{% endfor %}

--- a/_includes/software-projects.html
+++ b/_includes/software-projects.html
@@ -1,14 +1,45 @@
-{% for project in include.projects %}
-<article class="software-project">
-  <header>
-    <h3>{{ project.name }}</h3>
-    <p class="software-project-meta"><span class="software-project-status">{{ project.status }}</span> · {{ project.period }} · {{ project.technology }}</p>
-  </header>
-  <p>{{ project.summary }}</p>
-  <p class="software-project-links">
-    {% for link in project.links %}
-      <a href="{{ link.url | relative_url }}">{{ link.label }}</a>{% unless forloop.last %}<span aria-hidden="true"> · </span>{% endunless %}
-    {% endfor %}
-  </p>
-</article>
-{% endfor %}
+{% if include.presentation == "featured" %}
+  {% for project in include.projects %}
+  <div class="col-md-6">
+    <article class="card card-blog software-feature-card">
+      <div class="header">
+        {% include cloudflare_image.html image=project.image preset="thumbnail" class="image-header" alt=project.name %}
+      </div>
+      <div class="content">
+        <p class="card-category software-project-status">{{ project.status }} · {{ project.period }}</p>
+        <h3 class="card-title">{{ project.name }}</h3>
+        <p class="software-feature-technology">{{ project.technology }}</p>
+        <p class="text-description text-gray">{{ project.summary }}</p>
+        <p class="software-project-links">
+          {% for link in project.links %}
+            <a href="{{ link.url | relative_url }}" class="btn btn-info btn-round">{{ link.label }}</a>
+          {% endfor %}
+        </p>
+      </div>
+    </article>
+  </div>
+  {% endfor %}
+{% else %}
+  {% for project in include.projects %}
+  <article class="software-project software-project--{{ include.presentation }}">
+    <header class="software-project-header">
+      <div class="software-project-stamp">
+        <span class="software-project-status">{{ project.status }}</span>
+        <span class="software-project-period">{{ project.period }}</span>
+      </div>
+      <div class="software-project-heading">
+        <h3>{{ project.name }}</h3>
+        <p class="software-project-meta">{{ project.technology }}</p>
+      </div>
+    </header>
+    <div class="software-project-body">
+      <p>{{ project.summary }}</p>
+      <p class="software-project-links">
+        {% for link in project.links %}
+          <a href="{{ link.url | relative_url }}">{{ link.label }} <span aria-hidden="true">→</span></a>{% unless forloop.last %}<span class="software-link-divider" aria-hidden="true"> / </span>{% endunless %}
+        {% endfor %}
+      </p>
+    </div>
+  </article>
+  {% endfor %}
+{% endif %}

--- a/assets/css/software.css
+++ b/assets/css/software.css
@@ -162,12 +162,10 @@
 }
 
 .software-scholarship-note {
-  border-top: 1px solid #d0cdbc;
   font-size: 0.96rem;
   line-height: 1.65;
   margin: 3rem auto 0;
   max-width: 58rem;
-  padding-top: 1.5rem;
 }
 
 .software-archive-note {

--- a/assets/css/software.css
+++ b/assets/css/software.css
@@ -1,0 +1,48 @@
+.software-introduction {
+  font-size: 1.12em;
+}
+
+.software-project {
+  border-top: 1px solid #d0cdbc;
+  padding: 1.75rem 0 1.4rem;
+}
+
+.software-project h3 {
+  margin: 0 0 0.3rem;
+}
+
+.software-project-meta {
+  color: #555;
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.9em;
+  margin: 0 0 0.75rem;
+}
+
+.software-project-status {
+  color: #154c9e;
+  font-weight: 700;
+}
+
+.software-project-links {
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.94em;
+  margin-bottom: 0;
+}
+
+.software-archive-note {
+  border-left: 3px solid #f3dd78;
+  color: #555;
+  margin: 2rem 0 0;
+  padding: 0.4rem 0 0.4rem 1rem;
+}
+
+@media (max-width: 767px) {
+  .software-project {
+    padding: 1.35rem 0 1.2rem;
+  }
+
+  .software-project-meta,
+  .software-project-links {
+    line-height: 1.65;
+  }
+}

--- a/assets/css/software.css
+++ b/assets/css/software.css
@@ -1,21 +1,132 @@
 .software-introduction {
-  font-size: 1.12em;
+  font-size: 1.125rem;
+  line-height: 1.7;
+  margin: 0 auto;
+  max-width: 48rem;
+  padding: 1.5rem 0 2.5rem;
+}
+
+.software-section {
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  padding: 4.5rem 0;
+}
+
+.software-section .title-area {
+  margin-bottom: 3rem;
+}
+
+.software-section .title-area .description {
+  line-height: 1.65;
+}
+
+.software-feature-grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.software-feature-card {
+  height: calc(100% - 30px);
+  margin-bottom: 30px;
+}
+
+.software-feature-card .header {
+  background: #292929;
+  height: 15rem;
+  overflow: hidden;
+}
+
+.software-feature-card .image-header {
+  height: 100%;
+  object-fit: cover;
+}
+
+.software-feature-card .content {
+  display: flex;
+  flex-direction: column;
+  min-height: 23rem;
+  padding: 2rem 2.25rem 2.25rem;
+  text-align: left;
+}
+
+.software-feature-card .card-category {
+  margin: 0 0 0.75rem;
+}
+
+.software-feature-card .card-title {
+  font-size: 1.65rem;
+  line-height: 1.25;
+}
+
+.software-feature-technology {
+  color: #555;
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-bottom: 1.25rem;
+}
+
+.software-feature-card .text-description {
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.software-feature-card .software-project-links {
+  margin: auto 0 0;
+}
+
+.software-feature-card .btn {
+  margin: 0.4rem 0.35rem 0 0;
+}
+
+.software-project-list {
+  margin: 0 auto;
+  max-width: 58rem;
 }
 
 .software-project {
   border-top: 1px solid #d0cdbc;
-  padding: 1.75rem 0 1.4rem;
+  padding: 2rem 0;
+}
+
+.software-project:last-child {
+  border-bottom: 1px solid #d0cdbc;
+}
+
+.software-project-header {
+  align-items: baseline;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 10rem 1fr;
+}
+
+.software-project-stamp {
+  border-left: 3px solid #c5a47e;
+  color: #555;
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.82rem;
+  letter-spacing: 0.03em;
+  line-height: 1.5;
+  padding-left: 0.75rem;
+  text-transform: uppercase;
+}
+
+.software-project-stamp span {
+  display: block;
 }
 
 .software-project h3 {
-  margin: 0 0 0.3rem;
+  font-size: 1.35rem;
+  line-height: 1.25;
+  margin: 0 0 0.4rem;
 }
 
 .software-project-meta {
   color: #555;
   font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 0.9em;
-  margin: 0 0 0.75rem;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin: 0;
 }
 
 .software-project-status {
@@ -23,22 +134,98 @@
   font-weight: 700;
 }
 
+.software-project-body {
+  margin-left: 11.25rem;
+  max-width: 43rem;
+}
+
+.software-project-body > p:first-child {
+  font-size: 1rem;
+  line-height: 1.7;
+  margin: 1.15rem 0 1rem;
+}
+
 .software-project-links {
   font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 0.94em;
+  font-size: 0.9rem;
+  line-height: 1.7;
   margin-bottom: 0;
+}
+
+.software-project-links a {
+  display: inline-block;
+}
+
+.software-link-divider {
+  color: #999;
+  padding: 0 0.15rem;
+}
+
+.software-scholarship-note {
+  border-top: 1px solid #d0cdbc;
+  font-size: 0.96rem;
+  line-height: 1.65;
+  margin: 3rem auto 0;
+  max-width: 58rem;
+  padding-top: 1.5rem;
 }
 
 .software-archive-note {
   border-left: 3px solid #f3dd78;
   color: #555;
-  margin: 2rem 0 0;
-  padding: 0.4rem 0 0.4rem 1rem;
+  font-size: 1rem;
+  line-height: 1.7;
+  margin: 3rem auto 0;
+  max-width: 58rem;
+  padding: 0.45rem 0 0.45rem 1rem;
 }
 
 @media (max-width: 767px) {
+  .software-introduction {
+    font-size: 1.05rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .software-section {
+    padding: 3rem 0;
+  }
+
+  .software-section .title-area {
+    margin-bottom: 2rem;
+  }
+
+  .software-feature-card .header {
+    height: 12rem;
+  }
+
+  .software-feature-card .content {
+    min-height: 0;
+    padding: 1.6rem;
+  }
+
   .software-project {
-    padding: 1.35rem 0 1.2rem;
+    padding: 1.5rem 0;
+  }
+
+  .software-project-header {
+    gap: 0.8rem;
+    grid-template-columns: 1fr;
+  }
+
+  .software-project-stamp {
+    border-left: 0;
+    border-top: 2px solid #c5a47e;
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.55rem 0 0;
+  }
+
+  .software-project-stamp span {
+    display: inline;
+  }
+
+  .software-project-body {
+    margin-left: 0;
   }
 
   .software-project-meta,

--- a/software.md
+++ b/software.md
@@ -7,10 +7,40 @@ permalink: /software
 featured_image: /assets/img/software-banner.webp
 menu-order:     41
 menu-label:     Software
+stylesheet: /assets/css/software.css
 ---
-At [Miami](https://www.miamioh.edu/), I expected to study computer science.  I switched to mathematics after I got to [Maryland](http://www.umd.edu), but I had developed a decent set of software development skills.  I have written many, many programs.  Most of them were one-off and not worth mentioning.  Some of them were awarded a longer life and those I have posted to [GitHub](https://github.com/k3jph/) over the years.  
+<div class="software-introduction">
 
-Generally, I create software in the [Unix](http://www.unix.org/) tradition, this is, do one thing and do it well.  I have been a BSD user since about 1996.  BSD, like Linux, is a free Unix-like system but is constructed as a comprehensive system rather than cobbled together from parts.  This gives the BSD-based systems many advantages, and my platform of choice, these days, is MacOS X on the desktop and FreeBSD on the server.  One of the most interesting software projects I have here is [FreeGrep](https://github.com/howardjp/freegrep), a BSD-licensed implementation of the grep pattern matching suite.
+I have been writing software since Unix boxes were considerably more annoying.
+Some of it solves real problems; some of it exists because I wanted to know
+whether the idea would work. The distinction is often less tidy than it sounds.
 
-Now, most of my code projects support my [data science](/scholarship/) habit. I have written a few packages in R for [record linking](https://github.com/howardjp/phonics) and [financial waterfall charts](https://github.com/howardjp/waterfall).  These all follow the same design principles of doing one thing and doing it well.
+The projects below include applications, research software, developer tools,
+interactive experiments, and a long trail of Unix and BSD work. They are not a
+repository feed. They are the pieces that have earned an explanation: because
+they are current, still useful, published, historically consequential, or just
+too interesting to leave on an old Zip disk.
 
+</div>
+
+## Current Projects
+
+{% include software-projects.html projects=site.data.software.current %}
+
+## Maintained and Stable Research Software
+
+{% include software-projects.html projects=site.data.software.maintained %}
+
+The scholarly citations for `phonics` live in [Selected Work](/scholarship/).
+This page is where the packages themselves live: what they do, where to find
+them, and why they were built.
+
+## From the Archive
+
+{% include software-projects.html projects=site.data.software.archive %}
+
+<p class="software-archive-note">I studied mathematics rather than computer
+science after arriving at Maryland, but I never stopped writing programs. The
+older work reflects a durable preference for small tools with clear jobs, a
+great deal of BSD and Unix influence, and the useful habit of keeping the code
+around after the immediate reason for it has passed.</p>

--- a/software.md
+++ b/software.md
@@ -15,32 +15,45 @@ I have been writing software since Unix boxes were considerably more annoying.
 Some of it solves real problems; some of it exists because I wanted to know
 whether the idea would work. The distinction is often less tidy than it sounds.
 
-The projects below include applications, research software, developer tools,
-interactive experiments, and a long trail of Unix and BSD work. They are not a
-repository feed. They are the pieces that have earned an explanation: because
-they are current, still useful, published, historically consequential, or just
-too interesting to leave on an old Zip disk.
-
 </div>
 
-## Current Projects
+<section class="section section-gray software-section software-current-section">
+  <div class="container">
+    <div class="title-area">
+      <h2>Current Projects</h2>
+      <div class="separator separator-info"><img src="{{ '/assets/img/identity/kamon-info.svg' | relative_url }}" height="35" alt="" /></div>
+      <p class="description">Public work that is still being actively made and can be visited, used, or read now.</p>
+    </div>
+    <div class="row software-feature-grid">
+      {% include software-projects.html projects=site.data.software.current presentation="featured" %}
+    </div>
+  </div>
+</section>
 
-{% include software-projects.html projects=site.data.software.current %}
+<section class="section software-section software-research-section">
+  <div class="container">
+    <div class="title-area">
+      <h2>Research Software</h2>
+      <div class="separator separator-info"><img src="{{ '/assets/img/identity/kamon-info.svg' | relative_url }}" height="35" alt="" /></div>
+      <p class="description">Published packages, book companions, and durable tools built to make technical work inspectable and reusable.</p>
+    </div>
+    <div class="software-project-list">
+      {% include software-projects.html projects=site.data.software.maintained presentation="research" %}
+    </div>
+    <p class="software-scholarship-note">The scholarly citations for <code>phonics</code> live in <a href="{{ '/scholarship/' | relative_url }}">Selected Work</a>. This page is where the packages themselves live: what they do, where to find them, and why they were built.</p>
+  </div>
+</section>
 
-## Maintained and Stable Research Software
-
-{% include software-projects.html projects=site.data.software.maintained %}
-
-The scholarly citations for `phonics` live in [Selected Work](/scholarship/).
-This page is where the packages themselves live: what they do, where to find
-them, and why they were built.
-
-## From the Archive
-
-{% include software-projects.html projects=site.data.software.archive %}
-
-<p class="software-archive-note">I studied mathematics rather than computer
-science after arriving at Maryland, but I never stopped writing programs. The
-older work reflects a durable preference for small tools with clear jobs, a
-great deal of BSD and Unix influence, and the useful habit of keeping the code
-around after the immediate reason for it has passed.</p>
+<section class="section section-gray software-section software-archive-section">
+  <div class="container">
+    <div class="title-area">
+      <h2>From the Archive</h2>
+      <div class="separator separator-info"><img src="{{ '/assets/img/identity/kamon-info.svg' | relative_url }}" height="35" alt="" /></div>
+      <p class="description">Older projects kept because finished work, failed experiments, and useful little programs have a history too.</p>
+    </div>
+    <div class="software-project-list">
+      {% include software-projects.html projects=site.data.software.archive presentation="archive" %}
+    </div>
+    <p class="software-archive-note">I studied mathematics rather than computer science after arriving at Maryland, but I never stopped writing programs. The older work reflects a durable preference for small tools with clear jobs, a great deal of BSD and Unix influence, and the useful habit of keeping the code around after the immediate reason for it has passed.</p>
+  </div>
+</section>


### PR DESCRIPTION
## What changed

- replaces the autobiographical Software essay with a public project portfolio
- adds a structured project inventory at `_data/software.yml`, rendered through one reusable include
- presents 13 curated projects: 2 current, 4 maintained or stable research packages, and 7 historical projects
- rebuilds the page around the existing theme: full-width alternating sections, theme separators, image-led featured-project cards, and an editorial archival record

## Audit

Reviewed public repositories across the connected James-controlled accounts and organizations, the current site, its scholarly and book pages, GitHub references in the archive, and relevant project and release posts.

### Current portfolio

- tartan-maker — public 2026 package, documentation, PyPI release, and active CI
- Judith & Holofernes: The Fatal Image — public TypeScript source and live exhibition; substantive update September 2026

### Maintained / stable software

- Kami — stable, public JHU/APL modern-C++ agent-based modeling library; releases and documentation are available
- phonics — CRAN package, JOSS/JSS publications, public source updated August 2026
- cmna — CRAN companion package to the numerical-analysis book, public source updated July 2026
- waterfall — completed R visualization package; retained as Stable, not presented as active work

### Historical archive retained

FreeGrep; Virtual Bumblebees; WS2812B SPI Controller for ATtiny85; Phonics in Rust; LX; the early daemon/rpt/uwatch/write utilities; and the Kivu Ebola analysis artifact.

### Deliberate exclusions

Private work is not surfaced. This includes Interlocks, Greystoke, and Queen City Yard. Forks and mirrors (including NeuralCDE, torchcde, DCchoice, and Yorick) are excluded. Course work, templates, empty scaffolds, configuration repositories, site plumbing, and one-off analysis repositories were reviewed but do not receive portfolio entries. The dedicated Games area is not duplicated.

## Link and status notes

- Replaces old `howardjp` project URLs with current canonical `k3jph` repositories where applicable.
- The old FreeGrep repository has no README, but its purpose and historical significance are supported by the public repository description and site archive.
- No status is inferred from commit time alone. `Current` classifications are supported by recent substantive public work plus project documentation; `Stable` identifies completed or release-backed software that is not represented as active maintenance.

## Validation

- `git diff --check`
- YAML inventory parses successfully
- GitHub Actions full Jekyll, HTML, and link validation passed before this redesign; validation for the redesign is pending