### PR TITLE
Reconcile Service around current institutional roles

### DIFF
--- a/_data/service.yml
+++ b/_data/service.yml
@@ -1,0 +1,95 @@
+- organization: Maryland Defense Force
+  role: Captain
+  dates: 2013–Present
+  current: true
+  section: public
+  summary: "Lead operational teams for state missions, including statewide COVID-19 vaccination activity that delivered 8,285 shots; author policies on promotion, hazardous materials, professional writing, training, and operational standards."
+  detail_page: /service/maryland-defense-force/
+
+- organization: Society of the War of 1812 in Maryland
+  role: Treasurer · Member, Board of Managers
+  dates: 2025–Present
+  current: true
+  section: public
+  summary: "Hold fiduciary and governance responsibility for a 212-year-old Maryland charitable organization, including stewardship of approximately $700,000 in assets."
+
+- organization: Maryland Society, Sons of the American Revolution
+  role: Vice President, Charles Carroll of Carrollton Chapter
+  dates: 2026–Present
+  current: true
+  section: public
+  summary: "Serve in elected chapter leadership for the Maryland Society, Sons of the American Revolution."
+
+- organization: The Augustan Society
+  role: Member, Board of Directors · Vice-Justiciar for Maltese Heraldry
+  dates: 2024–Present
+  current: true
+  section: professional
+  summary: "Provide nonprofit governance, specialist heraldic advice, and curriculum development for a scholarly organization concerned with history, genealogy, heraldry, and chivalric traditions."
+
+- organization: Chapman and Hall / CRC Press
+  role: Series Editor, Focus Series in Analytics and Operations Research
+  dates: 2020–Present
+  current: true
+  section: professional
+  summary: "Provide editorial stewardship for a scholarly series at the intersection of analytics and operations research."
+
+- organization: Military Operations Research Journal
+  role: Associate Editor
+  dates: 2020–Present
+  current: true
+  section: professional
+  summary: "Contribute editorial review and professional judgment to the field’s principal scholarly journal."
+
+- organization: Howard County, Maryland
+  role: Chair and Member, Board of Appeals · Member, Charter Review Commission
+  dates: 2011–2021
+  current: false
+  section: past
+  summary: "Chaired formal adjudicatory proceedings, evaluated complex regulatory records, managed high-conflict public hearings, and issued structured decisions. Served on the 2019–2021 Charter Review Commission examining county-government design."
+  detail_page: /service/howard-county/
+
+- organization: Howard County, Maryland
+  role: Co-chair, Public Engagement in Land Use Planning Task Force
+  dates: 2008
+  current: false
+  section: past
+  summary: "Co-chaired the resident representatives on a county task force that produced recommendations on public engagement in land-use planning."
+  detail_page: /service/howard-county/
+
+- organization: Columbia Association
+  role: Budget Committee Member and Chair · Financial Advisory Committee Member
+  dates: 2004–2010
+  current: false
+  section: past
+  summary: "Reviewed budgets, long-term debt policy, allocation formulas, financial projections, and the financial consequences of redeveloping downtown Columbia; chaired the Budget Committee from 2005 to 2009."
+  detail_page: /service/columbia-association/
+
+- organization: Long Reach Community Association
+  role: Master Plan Committee Member
+  dates: 2010–2011
+  current: false
+  section: past
+  summary: "Helped prepare the Long Reach Village Center redevelopment recommendation that the Village Board refined into its master plan."
+  detail_page: /service/long-reach-community-association/
+
+- organization: Maryland Chapter Council, American Society for Public Administration
+  role: Council Member
+  dates: Historical service
+  current: false
+  section: past
+  summary: "Helped organize the chapter’s annual conference and awards program."
+
+- organization: University of Maryland Global Campus
+  role: Learning Management System Selection Project Participant
+  dates: Historical institutional service
+  current: false
+  section: past
+  summary: "Contributed faculty perspective to an institutional project selecting the university’s learning-management system."
+
+- organization: College Park Scholars Alumni Association
+  role: Founding and early governance work
+  dates: Historical service
+  current: false
+  section: past
+  summary: "Worked with university leaders to establish the alumni association and support its early governance."

--- a/_data/service.yml
+++ b/_data/service.yml
@@ -45,7 +45,7 @@
   role: Chair and Member, Board of Appeals · Member, Charter Review Commission
   dates: 2011–2021
   current: false
-  section: past
+  section: public
   summary: "Chaired formal adjudicatory proceedings, evaluated complex regulatory records, managed high-conflict public hearings, and issued structured decisions. Served on the 2019–2021 Charter Review Commission examining county-government design."
   detail_page: /service/howard-county/
 
@@ -53,7 +53,7 @@
   role: Co-chair, Public Engagement in Land Use Planning Task Force
   dates: 2008
   current: false
-  section: past
+  section: public
   summary: "Co-chaired the resident representatives on a county task force that produced recommendations on public engagement in land-use planning."
   detail_page: /service/howard-county/
 
@@ -61,7 +61,7 @@
   role: Budget Committee Member and Chair · Financial Advisory Committee Member
   dates: 2004–2010
   current: false
-  section: past
+  section: public
   summary: "Reviewed budgets, long-term debt policy, allocation formulas, financial projections, and the financial consequences of redeveloping downtown Columbia; chaired the Budget Committee from 2005 to 2009."
   detail_page: /service/columbia-association/
 
@@ -69,7 +69,7 @@
   role: Master Plan Committee Member
   dates: 2010–2011
   current: false
-  section: past
+  section: public
   summary: "Helped prepare the Long Reach Village Center redevelopment recommendation that the Village Board refined into its master plan."
   detail_page: /service/long-reach-community-association/
 
@@ -77,19 +77,19 @@
   role: Council Member
   dates: Historical service
   current: false
-  section: past
+  section: professional
   summary: "Helped organize the chapter’s annual conference and awards program."
 
 - organization: University of Maryland Global Campus
   role: Learning Management System Selection Project Participant
   dates: Historical institutional service
   current: false
-  section: past
+  section: professional
   summary: "Contributed faculty perspective to an institutional project selecting the university’s learning-management system."
 
 - organization: College Park Scholars Alumni Association
   role: Founding and early governance work
   dates: Historical service
   current: false
-  section: past
+  section: professional
   summary: "Worked with university leaders to establish the alumni association and support its early governance."

--- a/assets/css/service.css
+++ b/assets/css/service.css
@@ -27,12 +27,12 @@
   text-align: center;
 }
 
-.service-current h2,
-.service-current .description {
+.service-current h2 {
   color: #fff;
 }
 
 .service-current .description {
+  color: #feefa8;
   font-family: "Spectral", Georgia, serif;
   font-size: 1.08em;
   line-height: 1.55;
@@ -98,61 +98,81 @@
   line-height: 1.55;
 }
 
-.service-record {
+.service-history {
   margin: 0 auto 4rem;
 }
 
-.service-record > h2 {
+.service-history > h2 {
   margin-bottom: 0.5rem;
 }
 
-.service-record-introduction {
+.service-history-introduction {
   max-width: 52rem;
-  margin: 0 0 1.75rem;
+  margin: 0 0 2.5rem;
   color: #615d53;
   font-family: "Spectral", Georgia, serif;
   font-size: 1.08em;
   line-height: 1.55;
 }
 
+.service-history-group {
+  margin: 0 0 3rem;
+}
+
+.service-history-group h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1.45em;
+}
+
+.service-history-group-introduction {
+  margin: 0 0 1.25rem;
+  color: #786f5f;
+  font-family: "Spectral", Georgia, serif;
+  font-size: 1.03em;
+  line-height: 1.55;
+}
+
 .service-entry {
-  padding: 1.45rem 0;
+  padding: 1.2rem 0;
   border-top: 1px solid #d8d0bf;
 }
 
-.service-entry:last-child {
+.service-history-group .service-entry:last-child {
   border-bottom: 1px solid #d8d0bf;
 }
 
-.service-entry h3 {
-  margin: 0 0 0.25rem;
-  font-size: 1.35em;
+.service-entry h4 {
+  margin: 0;
+  color: #2e2c28;
+  font-size: 1.24em;
+  line-height: 1.3;
 }
 
-.service-entry h3 a {
+.service-entry h4 a {
   color: #2e2c28;
 }
 
-.service-entry h3 a:hover {
+.service-entry h4 a:hover {
   color: #154c9e;
 }
 
-.service-entry .service-role {
+.service-entry-meta {
+  margin: 0.35rem 0 0;
   color: #786f5f;
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.92em;
+  font-weight: 700;
+  line-height: 1.45;
 }
 
-.service-entry .service-dates {
-  color: #615d53;
+.service-entry-role {
+  color: #786f5f;
 }
 
 .service-entry .service-summary {
   max-width: 52rem;
-  margin: 0.8rem 0 0;
+  margin: 0.65rem 0 0;
   line-height: 1.58;
-}
-
-.service-entry--compact {
-  padding: 1.15rem 0;
 }
 
 @media (max-width: 991px) {
@@ -175,7 +195,7 @@
     padding: 1.25rem;
   }
 
-  .service-record {
+  .service-history {
     margin-bottom: 3rem;
   }
 }

--- a/assets/css/service.css
+++ b/assets/css/service.css
@@ -31,8 +31,8 @@
   color: #fff;
 }
 
-.service-current .description {
-  color: #feefa8;
+.service-current .title-area .description {
+  color: #feefa8 !important;
   font-family: "Spectral", Georgia, serif;
   font-size: 1.08em;
   line-height: 1.55;

--- a/assets/css/service.css
+++ b/assets/css/service.css
@@ -1,0 +1,181 @@
+.service-introduction {
+  max-width: 52rem;
+  margin: 0 auto 3rem;
+  font-family: "Spectral", Georgia, serif;
+  font-size: 1.18em;
+  line-height: 1.65;
+}
+
+.service-current {
+  width: 100vw;
+  margin: 0 calc(50% - 50vw) 4rem;
+  padding: 4rem 0;
+  background: #2b3c52;
+  color: #fff;
+}
+
+.service-current-inner {
+  max-width: 1170px;
+  margin: 0 auto;
+  padding: 0 15px;
+}
+
+.service-current .title-area {
+  max-width: 52rem;
+  margin: 0 auto 2.5rem;
+  padding: 0;
+  text-align: center;
+}
+
+.service-current h2,
+.service-current .description {
+  color: #fff;
+}
+
+.service-current .description {
+  font-family: "Spectral", Georgia, serif;
+  font-size: 1.08em;
+  line-height: 1.55;
+}
+
+.service-current .separator,
+.service-current .separator::before,
+.service-current .separator::after {
+  color: #feefa8;
+  border-color: #feefa8;
+}
+
+.service-current-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.service-current-card {
+  min-height: 100%;
+  padding: 1.45rem 1.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(16, 28, 44, 0.2);
+}
+
+.service-current-card h3 {
+  margin: 0 0 0.35rem;
+  color: #fff;
+  font-size: 1.25em;
+  line-height: 1.25;
+}
+
+.service-current-card h3 a {
+  color: #fff;
+}
+
+.service-current-card h3 a:hover {
+  color: #feefa8;
+}
+
+.service-role,
+.service-dates {
+  margin: 0;
+}
+
+.service-role {
+  color: #feefa8;
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.92em;
+  font-weight: 700;
+}
+
+.service-dates {
+  margin-top: 0.2rem;
+  color: rgba(255, 255, 255, 0.8);
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.86em;
+  font-weight: 700;
+}
+
+.service-current-card .service-summary {
+  margin: 0.85rem 0 0;
+  line-height: 1.55;
+}
+
+.service-record {
+  margin: 0 auto 4rem;
+}
+
+.service-record > h2 {
+  margin-bottom: 0.5rem;
+}
+
+.service-record-introduction {
+  max-width: 52rem;
+  margin: 0 0 1.75rem;
+  color: #615d53;
+  font-family: "Spectral", Georgia, serif;
+  font-size: 1.08em;
+  line-height: 1.55;
+}
+
+.service-entry {
+  padding: 1.45rem 0;
+  border-top: 1px solid #d8d0bf;
+}
+
+.service-entry:last-child {
+  border-bottom: 1px solid #d8d0bf;
+}
+
+.service-entry h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.35em;
+}
+
+.service-entry h3 a {
+  color: #2e2c28;
+}
+
+.service-entry h3 a:hover {
+  color: #154c9e;
+}
+
+.service-entry .service-role {
+  color: #786f5f;
+}
+
+.service-entry .service-dates {
+  color: #615d53;
+}
+
+.service-entry .service-summary {
+  max-width: 52rem;
+  margin: 0.8rem 0 0;
+  line-height: 1.58;
+}
+
+.service-entry--compact {
+  padding: 1.15rem 0;
+}
+
+@media (max-width: 991px) {
+  .service-current-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .service-current {
+    margin-bottom: 3rem;
+    padding: 3rem 0;
+  }
+
+  .service-current-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .service-current-card {
+    padding: 1.25rem;
+  }
+
+  .service-record {
+    margin-bottom: 3rem;
+  }
+}

--- a/service.md
+++ b/service.md
@@ -14,7 +14,7 @@ stylesheet: /assets/css/service.css
 
 Service is where an institutional idea has to survive contact with procedures, budgets, people, and consequences. My work outside ordinary employment has included formal public adjudication, state emergency operations, nonprofit fiduciary stewardship, board governance, and editorial responsibility. It is not a hobby adjacent to the rest of my work; it is part of how I learn whether a policy, a system, or a scholarly claim can function in the world.
 
-The active record comes first. The fuller history follows: public and civic duty, professional and scholarly stewardship, and the older local and institutional work from which much of it grew.
+The active record comes first. The historical record follows: public and civic duty, professional and scholarly stewardship, and the older local and institutional work from which much of it grew.
 
 </div>
 
@@ -39,47 +39,36 @@ The active record comes first. The fuller history follows: public and civic duty
   </div>
 </section>
 
-{% assign public_roles = site.data.service | where: "section", "public" %}
-<section class="service-record" aria-labelledby="public-civic-service">
-  <h2 id="public-civic-service">Public and Civic Service</h2>
-  <p class="service-record-introduction">Service to Maryland institutions, public bodies, and civic organizations.</p>
-
-  {% for role in public_roles %}
-  <article class="service-entry">
-    <h3>{% if role.detail_page %}<a href="{{ role.detail_page | relative_url }}">{% endif %}{{ role.organization }}{% if role.detail_page %}</a>{% endif %}</h3>
-    <p class="service-role">{{ role.role }}</p>
-    <p class="service-dates">{{ role.dates }}</p>
-    <p class="service-summary">{{ role.summary }}</p>
-  </article>
-  {% endfor %}
-</section>
-
-{% assign professional_roles = site.data.service | where: "section", "professional" %}
-<section class="service-record" aria-labelledby="professional-scholarly-service">
-  <h2 id="professional-scholarly-service">Professional and Scholarly Service</h2>
-  <p class="service-record-introduction">Editorial stewardship, learned-society governance, and specialist institutional work.</p>
-
-  {% for role in professional_roles %}
-  <article class="service-entry">
-    <h3>{{ role.organization }}</h3>
-    <p class="service-role">{{ role.role }}</p>
-    <p class="service-dates">{{ role.dates }}</p>
-    <p class="service-summary">{{ role.summary }}</p>
-  </article>
-  {% endfor %}
-</section>
-
-{% assign past_roles = site.data.service | where: "section", "past" %}
-<section class="service-record" aria-labelledby="past-service">
+{% assign historical_roles = site.data.service | where: "current", false %}
+{% assign public_roles = historical_roles | where: "section", "public" %}
+{% assign professional_roles = historical_roles | where: "section", "professional" %}
+<section class="service-history" aria-labelledby="past-service">
   <h2 id="past-service">Past Service</h2>
-  <p class="service-record-introduction">A compact record of completed public, civic, professional, and university service.</p>
+  <p class="service-history-introduction">A compact record of completed public, civic, professional, and university service.</p>
 
-  {% for role in past_roles %}
-  <article class="service-entry service-entry--compact">
-    <h3>{% if role.detail_page %}<a href="{{ role.detail_page | relative_url }}">{% endif %}{{ role.organization }}{% if role.detail_page %}</a>{% endif %}</h3>
-    <p class="service-role">{{ role.role }}</p>
-    <p class="service-dates">{{ role.dates }}</p>
-    <p class="service-summary">{{ role.summary }}</p>
-  </article>
-  {% endfor %}
+  <section class="service-history-group" aria-labelledby="public-civic-service">
+    <h3 id="public-civic-service">Public and Civic Service</h3>
+    <p class="service-history-group-introduction">County adjudication, local-government design, and community stewardship.</p>
+
+    {% for role in public_roles %}
+    <article class="service-entry">
+      <h4>{% if role.detail_page %}<a href="{{ role.detail_page | relative_url }}">{% endif %}{{ role.organization }}{% if role.detail_page %}</a>{% endif %}</h4>
+      <p class="service-entry-meta"><span class="service-entry-role">{{ role.role }}</span><span aria-hidden="true"> · </span><span>{{ role.dates }}</span></p>
+      <p class="service-summary">{{ role.summary }}</p>
+    </article>
+    {% endfor %}
+  </section>
+
+  <section class="service-history-group" aria-labelledby="professional-scholarly-service">
+    <h3 id="professional-scholarly-service">Professional and Scholarly Service</h3>
+    <p class="service-history-group-introduction">Professional-association, academic, and alumni governance work.</p>
+
+    {% for role in professional_roles %}
+    <article class="service-entry">
+      <h4>{{ role.organization }}</h4>
+      <p class="service-entry-meta"><span class="service-entry-role">{{ role.role }}</span><span aria-hidden="true"> · </span><span>{{ role.dates }}</span></p>
+      <p class="service-summary">{{ role.summary }}</p>
+    </article>
+    {% endfor %}
+  </section>
 </section>

--- a/service.md
+++ b/service.md
@@ -1,115 +1,85 @@
 ---
 id: 3003
-title: Service Philosophy
+title: Service
 date: 2015-10-13T18:22:06-04:00
 author: James Howard
 layout: page
 guid: service-philosophy
 featured_image: /assets/img/service.webp
 credits: _Image by [Creative Sustainability / Flickr](https://www.flickr.com/photos/aalto-cs/9669249877)._
-
+stylesheet: /assets/css/service.css
 ---
 
-Throughout my academic and public service careers, I have been driven by the
-intertwined principles of service and scholarship, recognizing the inherent
-value and symbiotic relationship between the two. This perspective has shaped my
-approach to education, research, and community engagement.
+<div class="service-introduction">
 
-My journey in public administration began with volunteering for the [Columbia
-Association's](http://www.columbiassociation.org) budget committee in 2004. This
-hands-on experience allowed me to witness firsthand the impact of budget
-decisions on the organization. Intrigued by the complexities of public finance,
-I pursued a Master of Public Administration (MPA) at the University of
-Baltimore. This educational pursuit provided me with a solid foundation in
-understanding the intricate relationship between budgeting, policy, and program
-implementation.
+Service is where an institutional idea has to survive contact with procedures, budgets, people, and consequences. My work outside ordinary employment has included formal public adjudication, state emergency operations, nonprofit fiduciary stewardship, board governance, and editorial responsibility. It is not a hobby adjacent to the rest of my work; it is part of how I learn whether a policy, a system, or a scholarly claim can function in the world.
 
-Eager to delve deeper into the field, I continued my academic journey by
-pursuing a Ph.D. in Public Policy, focusing on various land use issues. This
-research trajectory aligned seamlessly with my passion for examining the
-implications of flood insurance and evaluating program effectiveness. By
-exploring the intersections of policy, economics, and social welfare, I aimed to
-contribute to evidence-based decision-making and the improvement of public
-well-being.
+The active record comes first. The fuller history follows: public and civic duty, professional and scholarly stewardship, and the older local and institutional work from which much of it grew.
 
-While immersing myself in academia, I recognized the importance of community
-service and actively sought opportunities to make meaningful contributions
-beyond the confines of the classroom. Serving on the [Howard
-County](http://cc.howardcountymd.gov/) Public Engagement in Land Use Planning
-Task Force and later on the Howard County Board of Appeals allowed me to
-contribute to the development of land use policies and decisions. These
-experiences deepened my understanding of the challenges faced by communities and
-reinforced the need for informed and inclusive decision-making processes.
+</div>
 
-In addition to my commitment to community service, I have dedicated myself to
-supporting the profession and institutions that have nurtured my growth. As a
-member of the Maryland Chapter Council of the American Society for Public
-Administration, I played an active role in organizing our annual conference and
-awards program. By fostering connections between public administrators and
-professionals from diverse fields, I aimed to create opportunities for
-collaboration and knowledge sharing.
+{% assign current_roles = site.data.service | where: "current", true %}
+<section class="service-current">
+  <div class="service-current-inner">
+    <div class="title-area">
+      <h2>Current Service</h2>
+      <p class="description">Active appointments in public service, nonprofit governance, and professional stewardship.</p>
+    </div>
 
-As an adjunct faculty member, I have strived to serve the institutions I have
-been associated with. At the University of Maryland Global Campus, I actively
-participated in the Learning Management System Selection Project, contributing
-my insights to shape the educational technology landscape. Leveraging my status
-as an alumnus of the University of Maryland, College Park, I collaborated with
-university leaders to establish the [College Park Scholars Alumni
-Association](http://alumni.umd.edu/s/1132/index.aspx?sid=1132&gid=1&pgid=1256),
-fostering a vibrant community of scholars and practitioners.
+    <div class="service-current-grid">
+      {% for role in current_roles %}
+      <article class="service-current-card">
+        <h3>{% if role.detail_page %}<a href="{{ role.detail_page | relative_url }}">{% endif %}{{ role.organization }}{% if role.detail_page %}</a>{% endif %}</h3>
+        <p class="service-role">{{ role.role }}</p>
+        <p class="service-dates">{{ role.dates }}</p>
+        <p class="service-summary">{{ role.summary }}</p>
+      </article>
+      {% endfor %}
+    </div>
+  </div>
+</section>
 
-Recognizing the importance of engaging with the wider public, I have sought
-avenues to share my expertise and insights beyond academic circles. Writing
-articles for _The Conversation_, I have addressed pressing issues such as the
-[unsustainability of the National Flood Insurance
-Program](https://theconversation.com/texas-floods-highlight-need-to-reform-key-insurance-program-42235)
-and the [debates surrounding the Export-Import Bank of the United
-States](https://theconversation.com/why-congress-should-keep-the-imperiled-export-import-bank-42234).
-Through Ignite series talks, I have debunked misconceptions and shed light on
-complex challenges, ranging from the Defense Department's infamous $435 hammer
-to Maryland's stormwater management problem.
+{% assign public_roles = site.data.service | where: "section", "public" %}
+<section class="service-record" aria-labelledby="public-civic-service">
+  <h2 id="public-civic-service">Public and Civic Service</h2>
+  <p class="service-record-introduction">Service to Maryland institutions, public bodies, and civic organizations.</p>
 
-As an educator, I firmly believe that our responsibility extends beyond the
-boundaries of the classroom. Effective communication of our work to the public
-is paramount in ensuring its impact and relevance. By engaging with the public
-and fostering understanding, we empower individuals to make informed decisions
-and shape policies that reflect the latest research findings. Embracing this
-service philosophy, I am committed to bridging the gap between academia and the
-broader community, leveraging my expertise to contribute to a more informed and
-equitable society.
+  {% for role in public_roles %}
+  <article class="service-entry">
+    <h3>{% if role.detail_page %}<a href="{{ role.detail_page | relative_url }}">{% endif %}{{ role.organization }}{% if role.detail_page %}</a>{% endif %}</h3>
+    <p class="service-role">{{ role.role }}</p>
+    <p class="service-dates">{{ role.dates }}</p>
+    <p class="service-summary">{{ role.summary }}</p>
+  </article>
+  {% endfor %}
+</section>
 
-## Maryland Defense Force
+{% assign professional_roles = site.data.service | where: "section", "professional" %}
+<section class="service-record" aria-labelledby="professional-scholarly-service">
+  <h2 id="professional-scholarly-service">Professional and Scholarly Service</h2>
+  <p class="service-record-introduction">Editorial stewardship, learned-society governance, and specialist institutional work.</p>
 
-As a captain in the [Maryland Defense Force](/service/maryland-defense-force),
-I've had the opportunity to lead and coordinate teams during various emergency
-response scenarios. The role has enabled me to work alongside professionals from
-multiple disciplines, enhancing the state's overall emergency readiness. This
-service not only allows me to give back to my community but also enriches my own
-understanding of crisis management and public policy.
+  {% for role in professional_roles %}
+  <article class="service-entry">
+    <h3>{{ role.organization }}</h3>
+    <p class="service-role">{{ role.role }}</p>
+    <p class="service-dates">{{ role.dates }}</p>
+    <p class="service-summary">{{ role.summary }}</p>
+  </article>
+  {% endfor %}
+</section>
 
-## Howard County, Maryland
+{% assign past_roles = site.data.service | where: "section", "past" %}
+<section class="service-record" aria-labelledby="past-service">
+  <h2 id="past-service">Past Service</h2>
+  <p class="service-record-introduction">A compact record of completed public, civic, professional, and university service.</p>
 
-Serving on [Howard County](/service/howard-county)'s Board of Appeals and
-Charter Review Commission has been both an honor and a civic duty. These roles
-allowed me to influence local zoning and planning, as well as contribute to the
-legal frameworks guiding county operations. The experience has enhanced my
-academic work, offering practical insights into governance.
-
-## Long Reach Community Association
-
-In my role with the Long Reach Community Association, I was actively involved in
-creating the [Long Reach Village Center Master
-Plan](/service/long-reach-community-association). This wasn't just an academic
-exercise; it was a collaborative effort aimed at building a sustainable and
-inclusive community. The plan has since become a guiding blueprint for
-development in the area.
-
-## Columbia Association
-
-My years-long volunteer involvement with the [Columbia
-Association](/service/columbia-association)'s budget and financial advisory
-committees has been about more than just service. It involved scrutinizing
-budgets, making resource allocation recommendations, and aligning financial
-plans with the organization's mission. This hands-on experience complemented my
-academic background, bridging theory and real-world application.
-
+  {% for role in past_roles %}
+  <article class="service-entry service-entry--compact">
+    <h3>{% if role.detail_page %}<a href="{{ role.detail_page | relative_url }}">{% endif %}{{ role.organization }}{% if role.detail_page %}</a>{% endif %}</h3>
+    <p class="service-role">{{ role.role }}</p>
+    <p class="service-dates">{{ role.dates }}</p>
+    <p class="service-summary">{{ role.summary }}</p>
+  </article>
+  {% endfor %}
+</section>

--- a/service/howard-county.md
+++ b/service/howard-county.md
@@ -10,9 +10,12 @@ image: /assets/images/thomas-viaduct.webp
 
 ## Board of Appeals
 
-In 2011, I was appointed to the [Board of
-Appeals](http://cc.howardcountymd.gov/Zoning-Land-Use/Board-of-Appeals) for
-Howard County.  The Board of Appeals has two roles in Howard County.
+I served Howard County from 2011 through 2021 as a member and chair of
+the [Board of Appeals](http://cc.howardcountymd.gov/Zoning-Land-Use/Board-of-Appeals),
+and later on the Charter Review Commission. This is a historical public-service
+record; the appointments concluded in 2021.
+
+In 2011, I was appointed to the Board of Appeals for Howard County.  The Board of Appeals has two roles in Howard County.
 In the first role, cases for [conditional
 uses](https://en.wikipedia.org/wiki/Special-use_permit), sometimes
 called special use permits, are heard by the Board of Appeals Hearing

--- a/service/long-reach-community-association.md
+++ b/service/long-reach-community-association.md
@@ -9,7 +9,7 @@ image: /assets/images/long-reach-community-association.webp
 ---
 ## Master Plan Committee
 
-In 2009, the Howard County Government developed a set of steps each village must go through to complete a redevelopment of its village center.  One of these steps was developing a master plan for the redevelopment and in 2010 and 2011, this task in [Long Reach](http://longreach.org/) fell to a Master Plan Committee.  I sat committee with Columbia Council members Henry Dagenais, Ed Coleman, and Paul Bernard.  We produced a recommendation and the Village Board refined that recommendation into a master plan.  Both are linked to, below.
+In 2009, the Howard County Government developed a set of steps each village must go through to complete a redevelopment of its village center.  One of these steps was developing a master plan for the redevelopment and in 2010 and 2011, this task in [Long Reach](http://longreach.org/) fell to a Master Plan Committee. I served on that committee with Columbia Council members Henry Dagenais, Ed Coleman, and Paul Bernard.  We produced a recommendation and the Village Board refined that recommendation into a master plan.  Both are linked to, below.
 
 ### Documents
 

--- a/service/maryland-defense-force.md
+++ b/service/maryland-defense-force.md
@@ -13,37 +13,19 @@ redirect_from:
 cap="The Maryland Defense Force's distinctive unit insignia"
 alt="The Maryland Defense Force's distinctive unit insignia" %}
 
-As a captain in the [Maryland Defense Force
-(MDDF)](https://military.maryland.gov/mddf/Pages/default.aspx), I
-am proud to serve as a member of this highly trained and dedicated
-agency. The MDDF is a volunteer military organization that serves
-as a complement to the Maryland National Guard, providing critical
-support to the state's emergency response efforts. With a focus on
-disaster relief and other emergency services, the MDDF is a vital
-part of Maryland's emergency response capabilities.
+I have served as a captain in the [Maryland Defense Force
+(MDDF)](https://military.maryland.gov/mddf/Pages/default.aspx) since
+2013. The MDDF is Maryland's volunteer state-defense force, supporting
+the Maryland National Guard and state emergency operations.
 
-As a member of the MDDF, I have had the opportunity to work alongside
-other highly skilled and motivated individuals from a wide range
-of backgrounds. The MDDF is organized into several units, each with
-its own unique mission and focus. These units include medical and
-engineering, among others, each playing a critical role in supporting
-Maryland's emergency response efforts.
+My service has included leading operational teams during statewide
+COVID-19 vaccination activity, which delivered 8,285 shots, and
+authoring policies on promotion, hazardous materials, professional
+writing, training, and operational standards. The work is practical:
+organizing people and procedures when the state needs both to work.
 
-I have had the opportunity to lead and manage teams of volunteers
-in a variety of settings, from disaster response to training
-exercises. I have gained invaluable experience in coordinating and
-collaborating with other emergency response organizations and
-agencies, including the Maryland National Guard and the Federal
-Emergency Management Agency (FEMA).
-
-Overall, my experience in the MDDF has been incredibly rewarding
-and fulfilling. It has provided me with the opportunity to serve
-my community and my state in a meaningful way, while also developing
-important skills and knowledge that I can apply in both my personal
-and professional life.
-
-The following is a brief overview of my experience and
-accomplishments with the MDDF, as well as the MDDF itself.
+The following is a record of my service and of the Maryland Defense
+Force itself.
 
 ## History of the Maryland Defense Force
 


### PR DESCRIPTION
## Summary
- replaces the stale Service Philosophy essay with a current-first service record
- adds a structured service-data source for status, dates, roles, and summaries
- adds six current appointments: Maryland Defense Force; Society of the War of 1812 in Maryland; Maryland SAR chapter leadership; The Augustan Society; Chapman and Hall / CRC Press; Military Operations Research Journal
- preserves and reclassifies Howard County, Columbia Association, Long Reach, and other verified past institutional service
- makes narrow accuracy updates to the Maryland Defense Force, Howard County, and Long Reach detail pages

## Reconciliation sources
- James-Howard-Institutional-CV.pdf
- newer WHO UHC and NVAC specialized CVs
- existing dedicated service pages and the repository archive

## Notes
- no new thin dedicated pages were created for current nonprofit appointments
- ordinary employment, memberships, honors, awards, and public writing remain out of scope
- exact dates for ASPA, UMGC LMS selection work, and College Park Scholars alumni-association work remain unrecovered and are labeled as historical service rather than guessed
