### PR TITLE
Polish the homepage mobile hero

### DIFF
--- a/assets/css/jameshoward.css
+++ b/assets/css/jameshoward.css
@@ -586,3 +586,52 @@ body {
   padding-right: 10px;
   padding-left: 10px;
 }
+
+
+/*
+ * Mobile homepage: keep the accessibility skip link out of the visual
+ * composition until it is reached by keyboard focus, then give the hero
+ * statement a deliberate, readable three-line measure.
+ */
+.skip-link:not(:focus):not(:focus-visible) {
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (max-width: 767px) {
+  html,
+  body {
+    overflow-x: clip;
+  }
+
+  .home-mobile-hero .home-tagline {
+    width: min(100%, 29rem);
+    margin: 0 auto;
+    padding: 0 0.25rem;
+    color: #f8f8f8;
+    font-family: "Cinzel", "Times New Roman", serif;
+    font-size: clamp(1.25rem, 5.7vw, 1.65rem);
+    font-weight: 600;
+    line-height: 1.45;
+    letter-spacing: 0.025em;
+    text-align: center;
+  }
+
+  .home-mobile-hero .home-tagline span {
+    display: block;
+    white-space: nowrap;
+  }
+
+  /*
+   * The white visible after “What I Do” is the next content section,
+   * not a horizontal-overflow gap. Bring its heading into view sooner
+   * on phones so the transition reads as intentional.
+   */
+  #firstSection {
+    padding-top: 3rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -47,25 +47,33 @@ head_inject: >-
                     </div>
                 </div>
             </div>
-            <div class="content hidden-lg hidden-md">
+            <div class="content hidden-lg hidden-md home-mobile-hero">
                 <!-- Vertical Layout -->
                 <div class="row mt-4">
-                    <div class="col-12">
+                    <div class="col-xs-12">
                         <div class="row">
-                            <img src="/assets/img/identity/jameshoward-arms.svg"
-                                 class="img-responsive mx-auto" style="width: 50%;"
-                                 alt="James Howard coat of arms" />
+                            <div class="col-xs-12">
+                                <img src="/assets/img/identity/jameshoward-arms.svg"
+                                     class="img-responsive mx-auto" style="width: 50%;"
+                                     alt="James Howard coat of arms" />
+                            </div>
                         </div>
                         <div class="row pt-4 mt-3">
-                            <img src="/assets/img/identity/jameshoward-wordmark.svg"
-                                 class="img-responsive mx-auto"
-                                 style="width: 50%;"
-                                 alt="James Howard wordmark" />
-                            <div class="separator separator-info mt-2 mb-2">
-                                <img src="{{ '/assets/img/identity/kamon.svg' | relative_url
-                                          }}" height="35" alt="" />
+                            <div class="col-xs-12 text-center">
+                                <img src="/assets/img/identity/jameshoward-wordmark.svg"
+                                     class="img-responsive mx-auto"
+                                     style="width: 50%;"
+                                     alt="James Howard wordmark" />
+                                <div class="separator separator-info mt-2 mb-2">
+                                    <img src="{{ '/assets/img/identity/kamon.svg' | relative_url
+                                              }}" height="35" alt="" />
+                                </div>
+                                <h5 class="home-tagline">
+                                    <span>A Mathematician,</span>
+                                    <span>a Different Kind of Mathematician,</span>
+                                    <span>and a Statistician</span>
+                                </h5>
                             </div>
-                            <h5 style="margin-top: 0px;">A Mathematician, a Different Kind of<br />Mathematician, and a Statistician</h5>
                         </div>
                     </div>
                 </div>
@@ -107,8 +115,7 @@ head_inject: >-
                 <div class="separator separator-info">
                     <img src="{{ '/assets/img/identity/kamon-info.svg' | relative_url
                               }}" height="35" alt="" />
-                </div>
-            </div>
+                </div>            </div>
         </div>
         <div class="row">
             <a href="{{ '/scholarship' | relative_url }}">
@@ -227,8 +234,7 @@ head_inject: >-
         </div>
 
         <div id="masonry-container" class="row">
-            {% for post in site.posts limit: 8 %}
-            <div class="item col-md-4">
+            {% for post in site.posts limit: 8 %}            <div class="item col-md-4">
                 <div class="card card-blog">
                     <a href="{{ post.permalink | relative_url }}" class="header" aria-label="Read {{ post.title | escape }}">
                         {% if post.featured_image %}


### PR DESCRIPTION
- keeps the skip link accessible but visually hidden until keyboard focus
- puts the homepage statement in a real Bootstrap column and gives it intentional mobile line breaks
- removes the empty-looking mobile transition after “What I Do” by bringing the following section heading closer
- clips accidental horizontal overflow on narrow viewports