### PR TITLE
Compress the homepage mobile hero

### DIFF
--- a/assets/css/jameshoward.css
+++ b/assets/css/jameshoward.css
@@ -608,18 +608,31 @@ body {
     overflow-x: clip;
   }
 
+  .home-mobile-hero__arms img {
+    width: 55% !important;
+  }
+
+  .home-mobile-hero__wordmark {
+    margin-top: 0.25rem !important;
+    padding-top: 0.25rem !important;
+  }
+
+  .home-mobile-hero__wordmark > .col-xs-12 > img {
+    width: 57% !important;
+  }
+
   .home-mobile-hero .home-tagline {
     width: min(100%, 29rem);
     margin: 0 auto;
     padding: 0 0.25rem;
     color: #f8f8f8;
     font-family: "Cinzel", "Times New Roman", serif;
-    font-size: clamp(1.15rem, 5vw, 1.5rem);
+    font-size: clamp(1.1rem, 4.8vw, 1.42rem);
     font-weight: 600;
-    line-height: 1.35;
+    line-height: 1.28;
     letter-spacing: 0.02em;
     text-align: center;
-    margin-top: 1.25rem !important;
+    margin-top: 0.5rem !important;
   }
 
   .home-mobile-hero .home-tagline span {

--- a/index.html
+++ b/index.html
@@ -51,14 +51,14 @@ head_inject: >-
                 <!-- Vertical Layout -->
                 <div class="row mt-4">
                     <div class="col-xs-12">
-                        <div class="row">
+                        <div class="row home-mobile-hero__arms">
                             <div class="col-xs-12">
                                 <img src="/assets/img/identity/jameshoward-arms.svg"
                                      class="img-responsive mx-auto" style="width: 50%;"
                                      alt="James Howard coat of arms" />
                             </div>
                         </div>
-                        <div class="row pt-4 mt-3">
+                        <div class="row home-mobile-hero__wordmark">
                             <div class="col-xs-12 text-center">
                                 <img src="/assets/img/identity/jameshoward-wordmark.svg"
                                      class="img-responsive mx-auto"


### PR DESCRIPTION
- enlarges the arms and wordmark slightly
- removes most of the dead space between arms, name, divider, and tagline
- tightens the tagline’s line-height and mobile size