### PR TITLE
Refine homepage mobile hero hierarchy

### DIFF
--- a/assets/css/jameshoward.css
+++ b/assets/css/jameshoward.css
@@ -618,7 +618,7 @@ body {
   }
 
   .home-mobile-hero__wordmark > .col-xs-12 > img {
-    width: 57% !important;
+    width: 63% !important;
   }
 
   .home-mobile-hero .home-tagline {
@@ -632,7 +632,8 @@ body {
     line-height: 1.28;
     letter-spacing: 0.02em;
     text-align: center;
-    margin-top: 0.5rem !important;
+    margin-top: -1.25rem !important;
+    transform: translateY(-1.25rem);
   }
 
   .home-mobile-hero .home-tagline span {


### PR DESCRIPTION
## Summary

- enlarge the mobile homepage wordmark
- raise the tagline toward its divider while preserving its safe wrapped layout

## Validation

- CSS-only scoped mobile adjustment
